### PR TITLE
Allow debugger to be called using binding.pry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :development, :test do
   gem "guard-rack", "~> 2.2"
   gem "pry-byebug", "~> 3.7"
   gem "standard"
+  gem "pry", "~> 0.13.1"
 end
 
 # Test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,6 +371,7 @@ DEPENDENCIES
   hanami-view!
   i18n (~> 1.8)
   pg (~> 1.2)
+  pry (~> 0.13.1)
   pry-byebug (~> 3.7)
   puffing-billy (~> 2.2)
   puma (~> 4.0)

--- a/system/boot/debugger.rb
+++ b/system/boot/debugger.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Hanami.application.register_bootable :debugger do |container|
+  init do
+    require "pry" if Hanami.env?(:development) || Hanami.env?(:test)
+  end
+end


### PR DESCRIPTION
Pry was not previously required. Added a boot file to load the debugger when in development or test mode, otherwise, no.