### PR TITLE
Add break for lightweight out-of-the-box debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,10 +36,11 @@ gem "slim", "~> 4.0"
 
 # Development/test
 group :development, :test do
+  gem "break", "~> 0.21"
   gem "bundler-audit", "~> 0.6"
   gem "dotenv", "~> 2.7"
   gem "guard-rack", "~> 2.2"
-  gem "pry-byebug", "~> 3.7"
+  gem "pry"
   gem "standard"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,10 +63,10 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
+    break (0.21.0)
     bundler-audit (0.7.0.1)
       bundler (>= 1.2.0, < 3)
       thor (>= 0.18, < 2)
-    byebug (11.1.3)
     capybara (3.33.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -233,9 +233,6 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.9.0)
-      byebug (~> 11.0)
-      pry (~> 0.13.0)
     public_suffix (4.0.5)
     puffing-billy (2.3.1)
       addressable (~> 2.5)
@@ -350,6 +347,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  break (~> 0.21)
   bundler-audit (~> 0.6)
   capybara (~> 3.0)
   capybara-screenshot (~> 1.0)
@@ -371,7 +369,7 @@ DEPENDENCIES
   hanami-view!
   i18n (~> 1.8)
   pg (~> 1.2)
-  pry-byebug (~> 3.7)
+  pry
   puffing-billy (~> 2.2)
   puma (~> 4.0)
   rake (~> 13.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+begin
+  require "break"
+rescue LoadError => e
+  raise unless e.path == "break"
+end
+
 require "hanami"
 
 module AppPrototype


### PR DESCRIPTION
This works nicely with both `binding.pry` and `binding.irb` and has no runtime overhead.